### PR TITLE
Support base64 payloads for YOLO detection endpoints

### DIFF
--- a/API-ComputationalVision/App/Controllers/VisionController.py
+++ b/API-ComputationalVision/App/Controllers/VisionController.py
@@ -1,0 +1,79 @@
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends, HTTPException, status
+
+from App.Controllers.ControllerBase import ControllerBase
+from Domain.Models.Vision.ImageDetectionRequestModel import ImageDetectionRequestModel
+from Domain.Models.Vision.ImageDetectionResponseModel import ImageDetectionResponseModel
+from Domain.Models.Vision.VideoDetectionRequestModel import VideoDetectionRequestModel
+from Domain.Models.Vision.VideoDetectionResponseModel import VideoDetectionResponseModel
+from Infrastructure.CrossCutting.InjectionConfiguration import AppContainer
+from Services.ApplicationServices.YoloV12DetectionService import YoloV12DetectionService
+
+
+class VisionController(ControllerBase):
+    """REST endpoints exposing YOLOv12 object detection capabilities."""
+
+    def __init__(self) -> None:
+        super().__init__(prefix="vision", tags=["YOLOv12"])
+
+        @self.router.post(
+            "/detect-image",
+            response_model=ImageDetectionResponseModel,
+            summary="Detect objects in an image using YOLOv12",
+        )
+        @inject
+        async def detect_image(
+            request: ImageDetectionRequestModel,
+            service: YoloV12DetectionService = Depends(Provide[AppContainer.yolo_v12_service]),
+        ) -> ImageDetectionResponseModel:
+            if service is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Object detection service is not available.",
+                )
+
+            try:
+                return await service.detect_image(request.image_base64)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(exc),
+                ) from exc
+            except RuntimeError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=str(exc),
+                ) from exc
+
+        @self.router.post(
+            "/detect-video",
+            response_model=VideoDetectionResponseModel,
+            summary="Detect objects in a video using YOLOv12",
+        )
+        @inject
+        async def detect_video(
+            request: VideoDetectionRequestModel,
+            service: YoloV12DetectionService = Depends(Provide[AppContainer.yolo_v12_service]),
+        ) -> VideoDetectionResponseModel:
+            if service is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Object detection service is not available.",
+                )
+
+            try:
+                return await service.detect_video(
+                    video_data=request.video_base64,
+                    frame_interval=request.frame_interval,
+                    max_frames=request.max_frames,
+                )
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(exc),
+                ) from exc
+            except RuntimeError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=str(exc),
+                ) from exc

--- a/API-ComputationalVision/App/appsettings.json
+++ b/API-ComputationalVision/App/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "MAUI_HYBRID-BASE",
+  "APP_NAME": "API-ComputationalVision",
   "APP_VERSION": 1,
   "DATABASE_CONNECTIONS": [
     {

--- a/API-ComputationalVision/Domain/Models/Vision/BoundingBoxModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/BoundingBoxModel.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+
+
+class BoundingBoxModel(BaseModel):
+    """Represents the coordinates of a detected bounding box."""
+
+    xmin: float = Field(..., description="X coordinate for the top-left corner of the box.")
+    ymin: float = Field(..., description="Y coordinate for the top-left corner of the box.")
+    xmax: float = Field(..., description="X coordinate for the bottom-right corner of the box.")
+    ymax: float = Field(..., description="Y coordinate for the bottom-right corner of the box.")

--- a/API-ComputationalVision/Domain/Models/Vision/DetectionModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/DetectionModel.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+
+from Domain.Models.Vision.BoundingBoxModel import BoundingBoxModel
+
+
+class DetectionModel(BaseModel):
+    """Represents a single object detection entry."""
+
+    class_name: str = Field(..., description="Label predicted by the YOLO model for the detected object.")
+    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence score returned by the model.")
+    bounding_box: BoundingBoxModel = Field(..., description="Bounding box enclosing the detected object.")

--- a/API-ComputationalVision/Domain/Models/Vision/FrameDetectionsModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/FrameDetectionsModel.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+
+from Domain.Models.Vision.DetectionModel import DetectionModel
+
+
+class FrameDetectionsModel(BaseModel):
+    """Container with detections extracted from a single frame of a video."""
+
+    frame_index: int = Field(..., ge=0, description="Zero-based index of the processed frame in the original video.")
+    detections: list[DetectionModel] = Field(default_factory=list, description="List of detections found in the frame.")

--- a/API-ComputationalVision/Domain/Models/Vision/ImageDetectionRequestModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/ImageDetectionRequestModel.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+
+
+class ImageDetectionRequestModel(BaseModel):
+    """Request payload containing a base64 encoded image for YOLO processing."""
+
+    image_base64: str = Field(
+        ...,
+        min_length=1,
+        description="Base64 encoded representation of the image to analyse.",
+    )

--- a/API-ComputationalVision/Domain/Models/Vision/ImageDetectionResponseModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/ImageDetectionResponseModel.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+
+from Domain.Models.Vision.DetectionModel import DetectionModel
+
+
+class ImageDetectionResponseModel(BaseModel):
+    """Response payload returned for object detection on static images."""
+
+    model_version: str = Field(..., description="Identifier for the YOLO model that generated the detections.")
+    inference_time_ms: float = Field(..., ge=0.0, description="Total processing time reported by the model in milliseconds.")
+    detections: list[DetectionModel] = Field(default_factory=list, description="Detections found in the provided image.")

--- a/API-ComputationalVision/Domain/Models/Vision/VideoDetectionRequestModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/VideoDetectionRequestModel.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field
+
+
+class VideoDetectionRequestModel(BaseModel):
+    """Request payload containing a base64 encoded video for YOLO processing."""
+
+    video_base64: str = Field(
+        ...,
+        min_length=1,
+        description="Base64 encoded representation of the video to analyse.",
+    )
+    frame_interval: int = Field(
+        default=5,
+        ge=1,
+        description="Process one frame every N frames from the provided video stream.",
+    )
+    max_frames: int = Field(
+        default=60,
+        ge=1,
+        le=1000,
+        description="Maximum number of frames to process from the provided video stream.",
+    )

--- a/API-ComputationalVision/Domain/Models/Vision/VideoDetectionResponseModel.py
+++ b/API-ComputationalVision/Domain/Models/Vision/VideoDetectionResponseModel.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+
+from Domain.Models.Vision.FrameDetectionsModel import FrameDetectionsModel
+
+
+class VideoDetectionResponseModel(BaseModel):
+    """Response payload for object detection executed over a video."""
+
+    model_version: str = Field(..., description="Identifier for the YOLO model that generated the detections.")
+    frame_count: int = Field(..., ge=0, description="Total number of frames detected in the original video stream.")
+    processed_frames: int = Field(..., ge=0, description="Number of frames that were actually processed.")
+    frame_interval: int = Field(..., ge=1, description="Interval, in frames, used when sampling the video.")
+    inference_time_ms: float = Field(..., ge=0.0, description="Accumulated inference time across processed frames in milliseconds.")
+    frames: list[FrameDetectionsModel] = Field(default_factory=list, description="Detections grouped by processed frame.")

--- a/API-ComputationalVision/Infrastructure/CrossCutting/InjectionConfiguration.py
+++ b/API-ComputationalVision/Infrastructure/CrossCutting/InjectionConfiguration.py
@@ -4,6 +4,7 @@ from Domain.Utils import Utils
 from Infrastructure.Data.Api.DefaultApiAccess import DefaultApiAccess
 from Infrastructure.Data.Database.DefaultDatabaseAccess import DefaultDatabaseAccess
 from Services.ApplicationServices.HealthCheckServices import HealthCheckServices
+from Services.ApplicationServices.YoloV12DetectionService import YoloV12DetectionService
 
 
 class AppContainer(containers.DeclarativeContainer):
@@ -27,4 +28,5 @@ class AppContainer(containers.DeclarativeContainer):
                                              api=api_access,
                                              utils=utils,
                                              settings=app_settings)
+    yolo_v12_service = providers.Singleton(YoloV12DetectionService)
 

--- a/API-ComputationalVision/Services/ApplicationServices/YoloV12DetectionService.py
+++ b/API-ComputationalVision/Services/ApplicationServices/YoloV12DetectionService.py
@@ -1,0 +1,268 @@
+import asyncio
+import base64
+import os
+import tempfile
+import threading
+from pathlib import Path
+from binascii import Error as BinasciiError
+from typing import Optional, Union
+
+import cv2
+import numpy as np
+from ultralytics import YOLO
+
+from Domain.Models.Vision.DetectionModel import DetectionModel
+from Domain.Models.Vision.BoundingBoxModel import BoundingBoxModel
+from Domain.Models.Vision.FrameDetectionsModel import FrameDetectionsModel
+from Domain.Models.Vision.ImageDetectionResponseModel import ImageDetectionResponseModel
+from Domain.Models.Vision.VideoDetectionResponseModel import VideoDetectionResponseModel
+
+
+class YoloV12DetectionService:
+    """Service responsible for executing YOLOv12 detections over images and videos."""
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        confidence_threshold: float = 0.25,
+        iou_threshold: float = 0.45,
+        max_detections: int = 100,
+        video_max_frames: int = 60,
+        frame_interval: int = 5,
+    ) -> None:
+        self._model_path = model_path or os.getenv("YOLOV12_MODEL_PATH", "yolov8n.pt")
+        self._confidence_threshold = confidence_threshold
+        self._iou_threshold = iou_threshold
+        self._max_detections = max(1, max_detections)
+        self._video_max_frames = max(1, video_max_frames)
+        self._frame_interval = max(1, frame_interval)
+        self._model: Optional[YOLO] = None
+        self._model_lock = threading.Lock()
+        self._model_version = Path(self._model_path).stem or "yolov12"
+
+    async def detect_image(self, image_data: Union[bytes, str]) -> ImageDetectionResponseModel:
+        """Execute object detection on image payloads provided as bytes or base64 strings."""
+        image_bytes = self._normalize_input_bytes(image_data, "image")
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._detect_image_sync, image_bytes)
+
+    async def detect_video(
+        self,
+        video_data: Union[bytes, str],
+        frame_interval: Optional[int] = None,
+        max_frames: Optional[int] = None,
+    ) -> VideoDetectionResponseModel:
+        """Execute object detection on video payloads provided as bytes or base64 strings."""
+        video_bytes = self._normalize_input_bytes(video_data, "video")
+
+        interval = max(1, frame_interval or self._frame_interval)
+        frame_limit = max(1, max_frames or self._video_max_frames)
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._detect_video_sync, video_bytes, interval, frame_limit)
+
+    #region Private helpers
+    def _detect_image_sync(self, image_bytes: bytes) -> ImageDetectionResponseModel:
+        frame = self._decode_image(image_bytes)
+        result = self._predict_frame(frame)
+        detections = self._map_detections(result)
+        inference_time_ms = self._compute_inference_time(result)
+        return ImageDetectionResponseModel(
+            model_version=self._model_version,
+            inference_time_ms=inference_time_ms,
+            detections=detections,
+        )
+
+    def _detect_video_sync(self, video_bytes: bytes, frame_interval: int, frame_limit: int) -> VideoDetectionResponseModel:
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
+            temp_file.write(video_bytes)
+            temp_path = temp_file.name
+
+        capture = None
+        try:
+            capture = cv2.VideoCapture(temp_path)
+            if not capture.isOpened():
+                raise ValueError("Unable to decode the provided video stream. Ensure the file is a valid video.")
+
+            total_frames = int(capture.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+            processed_frames: list[FrameDetectionsModel] = []
+            total_inference_time = 0.0
+            frame_index = 0
+            processed_count = 0
+
+            while processed_count < frame_limit:
+                success, frame = capture.read()
+                if not success:
+                    break
+
+                if frame_index % frame_interval == 0:
+                    result = self._predict_frame(frame)
+                    detections = self._map_detections(result)
+                    processed_frames.append(
+                        FrameDetectionsModel(
+                            frame_index=frame_index,
+                            detections=detections,
+                        )
+                    )
+                    total_inference_time += self._compute_inference_time(result)
+                    processed_count += 1
+
+                frame_index += 1
+
+            if not processed_frames:
+                raise ValueError("No frames were processed from the provided video.")
+
+            frame_count = total_frames if total_frames > 0 else frame_index
+            return VideoDetectionResponseModel(
+                model_version=self._model_version,
+                frame_count=int(frame_count),
+                processed_frames=len(processed_frames),
+                frame_interval=frame_interval,
+                inference_time_ms=total_inference_time,
+                frames=processed_frames,
+            )
+        finally:
+            if capture is not None:
+                capture.release()
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
+
+    def _decode_image(self, image_bytes: bytes) -> np.ndarray:
+        np_array = np.frombuffer(image_bytes, dtype=np.uint8)
+        if np_array.size == 0:
+            raise ValueError("The uploaded image is empty or corrupted.")
+
+        frame = cv2.imdecode(np_array, cv2.IMREAD_COLOR)
+        if frame is None:
+            raise ValueError("Unable to decode the provided image. Ensure a valid image format is used.")
+        return frame
+
+    def _predict_frame(self, frame: np.ndarray):
+        model = self._ensure_model_loaded()
+        results = model.predict(
+            source=frame,
+            conf=self._confidence_threshold,
+            iou=self._iou_threshold,
+            max_det=self._max_detections,
+            verbose=False,
+        )
+        if not results:
+            raise RuntimeError("The YOLO model did not return any prediction results.")
+        return results[0]
+
+    def _ensure_model_loaded(self) -> YOLO:
+        if self._model is not None:
+            return self._model
+
+        with self._model_lock:
+            if self._model is None:
+                try:
+                    self._model = YOLO(self._model_path)
+                    if getattr(self._model, "ckpt_path", None):
+                        self._model_version = Path(str(self._model.ckpt_path)).stem or self._model_version
+                except Exception as exc:  # pragma: no cover - defensive
+                    raise RuntimeError(
+                        f"Unable to load YOLOv12 weights from '{self._model_path}'. "
+                        "Confirm the model file exists or provide YOLOV12_MODEL_PATH."
+                    ) from exc
+        return self._model
+
+    def _map_detections(self, result) -> list[DetectionModel]:
+        detections: list[DetectionModel] = []
+        boxes = getattr(result, "boxes", None)
+        if boxes is None:
+            return detections
+
+        names = getattr(result, "names", None)
+        if not names:
+            model = self._ensure_model_loaded()
+            names = getattr(model, "names", {})
+
+        for box in boxes:
+            if box.conf is None or box.cls is None or box.xyxy is None:
+                continue
+
+            confidence = float(box.conf[0])
+            if confidence < self._confidence_threshold:
+                continue
+
+            class_id = int(box.cls[0])
+            if isinstance(names, dict):
+                label = names.get(class_id, str(class_id))
+            elif isinstance(names, (list, tuple)) and 0 <= class_id < len(names):
+                label = names[class_id]
+            else:
+                label = str(class_id)
+            coordinates = box.xyxy[0].tolist()
+
+            detections.append(
+                DetectionModel(
+                    class_name=label,
+                    confidence=confidence,
+                    bounding_box=BoundingBoxModel(
+                        xmin=float(coordinates[0]),
+                        ymin=float(coordinates[1]),
+                        xmax=float(coordinates[2]),
+                        ymax=float(coordinates[3]),
+                    ),
+                )
+            )
+
+            if len(detections) >= self._max_detections:
+                break
+
+        return detections
+
+    @staticmethod
+    def _compute_inference_time(result) -> float:
+        speed = getattr(result, "speed", None)
+        if isinstance(speed, dict):
+            return float(sum(float(value) for value in speed.values()))
+        if isinstance(speed, (int, float)):
+            return float(speed)
+        return 0.0
+
+    def _normalize_input_bytes(self, data: Union[bytes, str], payload_type: str) -> bytes:
+        """Decode base64 strings and validate payloads before inference."""
+        if isinstance(data, bytes):
+            payload = data
+        elif isinstance(data, str):
+            stripped = data.strip()
+            if not stripped:
+                raise ValueError(f"No {payload_type} content received for detection.")
+
+            if stripped.lower().startswith("data:"):
+                parts = stripped.split(",", 1)
+                if len(parts) != 2:
+                    raise ValueError(
+                        f"The provided {payload_type} content is not a valid base64 data URI.",
+                    )
+                stripped = parts[1]
+
+            normalized = "".join(stripped.split())
+            if not normalized:
+                raise ValueError(f"No {payload_type} content received for detection.")
+
+            normalized = normalized.replace("-", "+").replace("_", "/")
+            padding = len(normalized) % 4
+            if padding:
+                normalized += "=" * (4 - padding)
+
+            try:
+                payload = base64.b64decode(normalized, validate=True)
+            except (BinasciiError, ValueError) as exc:
+                raise ValueError(
+                    f"The provided {payload_type} content is not valid base64 data.",
+                ) from exc
+        else:  # pragma: no cover - defensive programming
+            raise ValueError(f"Unsupported {payload_type} payload type: {type(data)!r}.")
+
+        if not payload:
+            raise ValueError(f"No {payload_type} content received for detection.")
+
+        return payload
+
+    #endregion

--- a/API-ComputationalVision/requirements.txt
+++ b/API-ComputationalVision/requirements.txt
@@ -10,3 +10,8 @@ pymysql
 oracledb
 pyodbc
 python-tds
+python-multipart
+numpy
+opencv-python-headless
+ultralytics
+torch


### PR DESCRIPTION
## Summary
- update the vision controller to accept JSON requests with base64-encoded image and video content
- add request models for image and video detection that carry base64 data and frame sampling preferences
- enhance the YOLOv12 detection service to decode base64 payloads while preserving existing inference logic

## Testing
- python -m compileall API-ComputationalVision

------
https://chatgpt.com/codex/tasks/task_e_68c88c6638d88330a23bda72b406882d