### PR TITLE
Add keras label filtering to console detection app

### DIFF
--- a/Console-ComputationalVision/README.md
+++ b/Console-ComputationalVision/README.md
@@ -38,6 +38,8 @@ window has focus.
 - `--iou`: Intersection-over-Union threshold used by non-max suppression.
 - `--max-detections`: maximum number of detections drawn per frame.
 - `--device`: optional torch device (e.g. `cuda:0` or `cpu`).
+- `--labels`: path to a custom `labels.txt` file. When omitted the app searches the
+  `keras_models` directory and will only display detections for the labels found there.
 
 ## 📝 Notes
 
@@ -45,3 +47,6 @@ window has focus.
   and the `(x, y)` coordinates of each detection's center.
 - The frame rate indicator at the top-left corner helps you monitor the
   inference speed of your hardware.
+- When a custom labels file is present under `keras_models/converted_savedmodel/labels.txt`
+  only those classes will be displayed in the output, ensuring the detections stay
+  focused on the trained products.


### PR DESCRIPTION
## Summary
- load custom labels from the keras_models directory (or a user-provided path) when starting the console detector
- filter detections so only classes listed in the labels file are rendered, keeping focus on the trained products
- document the new --labels option and behaviour in the console README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc9d666374833089eabc422ab3ec20