### PR TITLE
Enhance G-code panel UX and shutdown handling

### DIFF
--- a/Console-ComputationalVision/presentation/gui_app.py
+++ b/Console-ComputationalVision/presentation/gui_app.py
@@ -459,6 +459,10 @@ class GuiApp:
             pass
         self._dispatcher.stop()
         self._poller.stop()
+        try:
+            self.gcode_panel.shutdown()
+        except Exception:
+            pass
         sys.stdout = self._original_stdout
         sys.stderr = self._original_stderr
         self.root.quit()

--- a/Console-ComputationalVision/presentation/widgets/gcode_sender_panel.py
+++ b/Console-ComputationalVision/presentation/widgets/gcode_sender_panel.py
@@ -43,7 +43,8 @@ class GcodeSenderPanel:
 
         self._ports_lookup: dict[str, dict] = {}
         self._busy = False
-        self._connected = False
+        self._connected_port: str | None = None
+        self._last_position: Position | None = None
 
         self.serial_port_var = tk.StringVar()
         ttk.Label(self.frame, text="Serial port").grid(row=0, column=0, sticky="w", pady=2, padx=4)
@@ -61,8 +62,19 @@ class GcodeSenderPanel:
         self.disconnect_button = ttk.Button(button_bar, text="Disconnect", command=self._disconnect, state="disabled")
         self.disconnect_button.grid(row=0, column=1, sticky="ew")
 
+        position_frame = ttk.Frame(self.frame)
+        position_frame.grid(row=2, column=0, columnspan=3, sticky="ew", padx=4, pady=(4, 2))
+        ttk.Label(position_frame, text="Current position").grid(row=0, column=0, sticky="w", padx=(0, 6))
+        self.position_vars = {axis: tk.StringVar(value="-") for axis in ("x", "y", "z")}
+        for idx, axis in enumerate(("x", "y", "z")):
+            label_col = idx * 2 + 1
+            entry_col = label_col + 1
+            ttk.Label(position_frame, text=f"{axis.upper()}:").grid(row=0, column=label_col, sticky="w")
+            entry = ttk.Entry(position_frame, textvariable=self.position_vars[axis], width=8, justify="right", state="readonly")
+            entry.grid(row=0, column=entry_col, sticky="w", padx=(0, 6))
+
         coord_frame = ttk.LabelFrame(self.frame, text="Move")
-        coord_frame.grid(row=2, column=0, columnspan=3, sticky="ew", padx=4, pady=(0, 4))
+        coord_frame.grid(row=3, column=0, columnspan=3, sticky="ew", padx=4, pady=(0, 4))
         for col in range(4):
             coord_frame.columnconfigure(col, weight=1 if col == 1 else 0)
 
@@ -78,29 +90,40 @@ class GcodeSenderPanel:
         ttk.Entry(coord_frame, textvariable=self.feedrate_var).grid(row=row, column=1, sticky="ew", pady=2)
         row += 1
 
+        self.feedrate_error_var = tk.StringVar(value="")
+        ttk.Label(coord_frame, textvariable=self.feedrate_error_var, foreground="red").grid(
+            row=row, column=0, columnspan=2, sticky="w"
+        )
+        row += 1
+
         action_bar = ttk.Frame(coord_frame)
         action_bar.grid(row=row, column=0, columnspan=2, sticky="ew", pady=(4, 0))
         action_bar.columnconfigure(0, weight=1)
         action_bar.columnconfigure(1, weight=1)
+        action_bar.columnconfigure(2, weight=1)
         self.move_button = ttk.Button(action_bar, text="Send", command=self._send_move, state="disabled")
         self.move_button.grid(row=0, column=0, sticky="ew", padx=(0, 4))
         self.home_button = ttk.Button(action_bar, text="Home", command=self._home, state="disabled")
         self.home_button.grid(row=0, column=1, sticky="ew")
+        self.command_status_var = tk.StringVar(value="")
+        ttk.Label(action_bar, textvariable=self.command_status_var, foreground="gray").grid(
+            row=0, column=2, sticky="w", padx=(6, 0)
+        )
 
         command_frame = ttk.LabelFrame(self.frame, text="Raw command")
-        command_frame.grid(row=3, column=0, columnspan=3, sticky="ew", padx=4, pady=(0, 4))
+        command_frame.grid(row=4, column=0, columnspan=3, sticky="ew", padx=4, pady=(0, 4))
         command_frame.columnconfigure(0, weight=1)
         self.command_var = tk.StringVar()
         ttk.Entry(command_frame, textvariable=self.command_var).grid(row=0, column=0, sticky="ew", pady=2)
         self.command_button = ttk.Button(command_frame, text="Send", command=self._send_raw_command, state="disabled")
         self.command_button.grid(row=0, column=1, sticky="ew", padx=(4, 0))
 
-        ttk.Label(self.frame, text="G-code Logs").grid(row=4, column=0, columnspan=3, sticky="w", padx=4)
+        ttk.Label(self.frame, text="G-code Logs").grid(row=5, column=0, columnspan=3, sticky="w", padx=4)
         self.log_text = scrolledtext.ScrolledText(self.frame, height=8, state="disabled", wrap="word")
-        self.log_text.grid(row=5, column=0, columnspan=3, sticky="nsew", padx=4, pady=(0, 4))
+        self.log_text.grid(row=6, column=0, columnspan=3, sticky="nsew", padx=4, pady=(0, 4))
 
         self.status_var = tk.StringVar(value="Idle")
-        ttk.Label(self.frame, textvariable=self.status_var).grid(row=6, column=0, columnspan=3, sticky="w", padx=4)
+        ttk.Label(self.frame, textvariable=self.status_var).grid(row=7, column=0, columnspan=3, sticky="w", padx=4)
 
         self.refresh_ports()
         self._register_bus_handlers()
@@ -109,7 +132,7 @@ class GcodeSenderPanel:
         self._bus.subscribe(GCODE_LOG_TOPIC, self._on_log)
         self._bus.subscribe(COMMAND_STATUS_TOPIC, self._on_status)
         self._bus.subscribe(GCODE_INSTRUMENT_TOPIC, self._on_instrument)
-        self._bus.subscribe(POSITION_TOPIC, lambda _event: self._update_buttons())
+        self._bus.subscribe(POSITION_TOPIC, self._on_position)
 
     def refresh_ports(self) -> None:
         ports = self._connection.list_ports()
@@ -120,13 +143,25 @@ class GcodeSenderPanel:
             label = f"{port['device']} ({description})"
             labels.append(label)
             self._ports_lookup[label] = port
+        if self._connected_port and self._connected_port not in (p.get("device") for p in ports):
+            label = f"{self._connected_port} (connected)"
+            labels.append(label)
+            self._ports_lookup[label] = {"device": self._connected_port}
         update_combobox_options(
             self.serial_combo,
             self.serial_port_var,
             labels,
             placeholder="No ports available",
-            preserve_selection=False,
+            preserve_selection=True,
         )
+        if self._connected_port:
+            for label in labels:
+                info = self._ports_lookup.get(label, {})
+                if info.get("device") == self._connected_port:
+                    self.serial_port_var.set(label)
+                    self.serial_combo.set(label)
+                    break
+        self._update_buttons()
 
     def _connect(self) -> None:
         label = self.serial_port_var.get()
@@ -139,14 +174,23 @@ class GcodeSenderPanel:
         except Exception as exc:
             messagebox.showerror("Connection failed", str(exc))
             return
-        self._connected = True
+        self._connected_port = info["device"]
         self.status_var.set(f"Connected to {info['device']}")
+        self._on_log(f"Connected to {info['device']}")
         self._update_buttons()
 
     def _disconnect(self) -> None:
-        self._connection.disconnect()
-        self._connected = False
+        if not self._connection.is_connected():
+            return
+        port = self._connected_port or self.serial_port_var.get()
+        try:
+            self._connection.disconnect()
+        finally:
+            self._connected_port = None
         self.status_var.set("Disconnected")
+        if port:
+            self._on_log(f"Disconnected from {port}")
+        self._update_position_display(None)
         self._update_buttons()
 
     def _send_move(self) -> None:
@@ -162,8 +206,14 @@ class GcodeSenderPanel:
             feedrate = ensure_positive_float(self.feedrate_var.get() or "200", "Feedrate")
         except ValidationError as exc:
             message = "Feedrate must be positive" if "positive" in str(exc).lower() else "Enter a numeric feedrate"
-            messagebox.showerror("Invalid feedrate", message)
+            self.feedrate_error_var.set(message)
             return
+        self.feedrate_error_var.set("")
+        self._on_log(
+            "Move command: X={x:.3f} Y={y:.3f} Z={z:.3f} F={f:.1f}".format(
+                x=coords["x"], y=coords["y"], z=coords["z"], f=feedrate
+            )
+        )
         self._send_coordinates.execute(Position(**coords), Feedrate(feedrate))
 
     def _home(self) -> None:
@@ -171,14 +221,17 @@ class GcodeSenderPanel:
             feedrate = ensure_positive_float(self.feedrate_var.get() or "200", "Feedrate")
         except ValidationError as exc:
             message = "Feedrate must be positive" if "positive" in str(exc).lower() else "Enter a numeric feedrate"
-            messagebox.showerror("Invalid feedrate", message)
+            self.feedrate_error_var.set(message)
             return
+        self.feedrate_error_var.set("")
+        self._on_log(f"Home command with F={feedrate:.1f}")
         self._home_machine.execute(Feedrate(feedrate))
 
     def _send_raw_command(self) -> None:
         command = self.command_var.get().strip()
         if not command:
             return
+        self._on_log(f">> {command}")
         self._send_raw.execute(command, wait_for_ok=False)
         self.command_var.set("")
 
@@ -193,12 +246,13 @@ class GcodeSenderPanel:
     def _on_status(self, status) -> None:
         if status == "Idle":
             self._busy = False
+            self.command_status_var.set("")
         elif status == "refresh-position":
             self._poller.trigger()
             return
         else:
             self._busy = True
-            self.status_var.set(status)
+            self.command_status_var.set(str(status))
         self._update_buttons()
 
     def _on_instrument(self, payload) -> None:
@@ -220,6 +274,15 @@ class GcodeSenderPanel:
             parts.append(f"{key}={ordered[key]}")
         return "GRBL_EVENT " + " ".join(parts)
 
+    def _on_position(self, event) -> None:
+        position = getattr(event, "position", None)
+        if isinstance(position, Position):
+            self._last_position = position
+        else:
+            self._last_position = None
+        self._update_position_display(self._last_position)
+        self._update_buttons()
+
     def _update_buttons(self) -> None:
         connected = self._connection.is_connected()
         busy = self._busy or self._dispatcher.busy()
@@ -231,3 +294,21 @@ class GcodeSenderPanel:
         else:
             set_group_state((self.connect_button,), enabled=True)
             set_group_state((self.disconnect_button,), enabled=False)
+        if not connected:
+            self.command_status_var.set("")
+
+    def _update_position_display(self, position: Position | None) -> None:
+        if position is None:
+            for var in self.position_vars.values():
+                var.set("-")
+            return
+        self.position_vars["x"].set(f"{position.x:.3f}")
+        self.position_vars["y"].set(f"{position.y:.3f}")
+        self.position_vars["z"].set(f"{position.z:.3f}")
+
+    def shutdown(self) -> None:
+        if self._connection.is_connected():
+            try:
+                self._connection.disconnect()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- show live machine coordinates and command status in the G-code sender panel
- improve serial port refresh, feedrate validation feedback, and logging of commands
- ensure the GUI disconnects the G-code hardware when shutting down

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d9e4c4afc48330b77a17d5fe0afcaa